### PR TITLE
.with_status_code can now take a raw number

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -75,6 +75,42 @@ impl StatusCode {
     }
 }
 
+impl From<i8> for StatusCode {
+    fn from(in_code: i8) -> StatusCode {
+        StatusCode(in_code as u16)
+    }
+}
+
+impl From<u8> for StatusCode {
+    fn from(in_code: u8) -> StatusCode {
+        StatusCode(in_code as u16)
+    }
+}
+
+impl From<i16> for StatusCode {
+    fn from(in_code: i16) -> StatusCode {
+        StatusCode(in_code as u16)
+    }
+}
+
+impl From<u16> for StatusCode {
+    fn from(in_code: u16) -> StatusCode {
+        StatusCode(in_code)
+    }
+}
+
+impl From<i32> for StatusCode {
+    fn from(in_code: i32) -> StatusCode {
+        StatusCode(in_code as u16)
+    }
+}
+
+impl From<u32> for StatusCode {
+    fn from(in_code: u32) -> StatusCode {
+        StatusCode(in_code as u16)
+    }
+}
+
 /// Represents a HTTP header.
 /// 
 /// The easiest way to create a `Header` object is to call `from_str`.

--- a/src/response.rs
+++ b/src/response.rs
@@ -231,8 +231,8 @@ impl<R> Response<R> where R: Read {
 
     /// Returns the same request, but with a different status code.
     #[inline]
-    pub fn with_status_code(mut self, code: StatusCode) -> Response<R> {
-        self.status_code = code;
+    pub fn with_status_code<S>(mut self, code: S) -> Response<R> where S: Into<StatusCode> {
+        self.status_code = code.into();
         self
     }
 


### PR DESCRIPTION
This is a real modification to the code, not just to bring it up-to-date.

The `From`/`Into`/etc. traits didn't exist at that time. It's much more convenient to be able to write `.with_status_code(404)` rather than `.with_status_code(tiny_http::StatusCode(404))`.