### PR TITLE
Add autodoc generation and autopublish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: rust
 
-env:
-  global:
-    - secure: V+q4PfXMjLYlYowARj1IN+pHrbBEPO7v20Xhu/8VMhMEwQIh8PgB5bfHFT7UNJa5eWf2bi5e0dM1SpblTT67lfWUpg4Gn3yf2pg/6BgM75NrZl3tK5Uh435fXO/4ne+iOHPRl7wIDKf/WRxCNor5hI8gOAziCuv7T1IE1qZzIF8=
-
-after_script:
-  - cargo doc
-  - cp -R target/doc doc
-  - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
-  # benchmarking
-  - sudo apt-get install apache2 apache2-utils nodejs
-  - ./.travis-bench
+after_success:
+  - |
+        [ $TRAVIS_BRANCH = master ] &&
+        [ $TRAVIS_PULL_REQUEST = false ] &&
+        cargo publish --token ${CRATESIO_TOKEN}
+  - |
+        [ $TRAVIS_BRANCH = master ] &&
+        [ $TRAVIS_PULL_REQUEST = false ] &&
+        cargo doc &&
+        echo '<meta http-equiv=refresh content=0;url=[CRATE NAME]/index.html>' > target/doc/index.html &&
+        git clone https://github.com/davisp/ghp-import &&
+        ./ghp-import/ghp-import -n target/doc &&
+        git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages


### PR DESCRIPTION
You need to add `GH_TOKEN` and `CRATESIO_TOKEN` environment variables in travis's configuration page, and create a `gh-pages` branch in the repo (whose content doesn't matter, as it will be force-pushed upon).

The next step will be to modify the readme to point to the generated docs.