### PR TITLE
Remove the dependency to rust-crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["pierre.krieger1708@gmail.com", "coreyf@rwell.org"]
 
 [dependencies]
 ascii = "0.4"
-rust-crypto = "0.2"
 encoding = "0.2"
 rustc-serialize = "0.3"
 url = "0.2"


### PR DESCRIPTION
It's unused, plus it uses gcc and depends on time, which is a big no-no on windows.