### PR TITLE
Rework the way messages are being dispatched to the Server object

### DIFF
--- a/src/util/messages_queue.rs
+++ b/src/util/messages_queue.rs
@@ -1,0 +1,42 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, Condvar};
+
+pub struct MessagesQueue<T> where T: Send {
+    queue: Mutex<VecDeque<T>>,
+    condvar: Condvar,
+}
+
+impl<T> MessagesQueue<T> where T: Send {
+    pub fn with_capacity(capacity: usize) -> Arc<MessagesQueue<T>> {
+        Arc::new(MessagesQueue {
+            queue: Mutex::new(VecDeque::with_capacity(capacity)),
+            condvar: Condvar::new(),
+        })
+    }
+
+    /// Pushes an element to the queue.
+    pub fn push(&self, value: T) {
+        let mut queue = self.queue.lock().unwrap();
+        queue.push_back(value);
+        self.condvar.notify_one();
+    }
+
+    /// Pops an element. Blocks until one is available.
+    pub fn pop(&self) -> T {
+        let mut queue = self.queue.lock().unwrap();
+
+        loop {
+            if let Some(elem) = queue.pop_front() {
+                return elem;
+            }
+
+            queue = self.condvar.wait(queue).unwrap();
+        }
+    }
+
+    /// Tries to pop an element without blocking.
+    pub fn try_pop(&self) -> Option<T> {
+        let mut queue = self.queue.lock().unwrap();
+        queue.pop_front()
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -17,6 +17,7 @@ pub use self::closable_tcp_stream::ClosableTcpStream;
 pub use self::custom_stream::CustomStream;
 pub use self::encoding_decoder::EncodingDecoder;
 pub use self::equal_reader::EqualReader;
+pub use self::messages_queue::MessagesQueue;
 pub use self::sequential::{SequentialReaderBuilder, SequentialReader};
 pub use self::sequential::{SequentialWriterBuilder, SequentialWriter};
 pub use self::task_pool::TaskPool;
@@ -28,6 +29,7 @@ mod closable_tcp_stream;
 mod custom_stream;
 mod encoding_decoder;
 mod equal_reader;
+mod messages_queue;
 mod sequential;
 mod task_pool;
 


### PR DESCRIPTION
Should fix #68 

Behavior right now: there are two channels, one for new client connections, and one for HTTP requests sent by an existing connection. When the user calls `recv()`, tiny-http checks whether one of these channels has data waiting, then sleeps 2ms, then checks, then sleeps.

Behavior after this PR: a single `MessageQueue` is shared between new client connections and new HTTP requests. When the user calls `recv()`, it checks whether the queue contains a message, and blocks on a condition variable if there aren't any. When one of the background threads receives a new connection or a new requests, it wakes one of the sleeping threads blocked on the condvar.

Therefore while idle, tiny-http should consume 0% CPU and will only be awakened when a socket receives some data.
