### PR TITLE
Add some trait impls for HTTPVersion

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -220,7 +220,7 @@ impl Iterator for ClientConnection {
             };
 
             // checking HTTP version
-            if *rq.get_http_version() > HTTPVersion(1, 1) {
+            if *rq.get_http_version() > (1, 1) {
                 let writer = self.sink.next().unwrap();
                 let response =
                     Response::from_string("This server only supports HTTP versions 1.0 and 1.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -280,6 +280,38 @@ impl PartialOrd for HTTPVersion {
     }
 }
 
+impl PartialEq<(u8, u8)> for HTTPVersion {
+    fn eq(&self, &(major, minor): &(u8, u8)) -> bool {
+        self.eq(&HTTPVersion(major, minor))
+    }
+}
+
+impl PartialEq<HTTPVersion> for (u8, u8) {
+    fn eq(&self, other: &HTTPVersion) -> bool {
+        let &(major, minor) = self;
+        HTTPVersion(major, minor).eq(other)
+    }
+}
+
+impl PartialOrd<(u8, u8)> for HTTPVersion {
+    fn partial_cmp(&self, &(major, minor): &(u8, u8)) -> Option<Ordering> {
+        self.partial_cmp(&HTTPVersion(major, minor))
+    }
+}
+
+impl PartialOrd<HTTPVersion> for (u8, u8) {
+    fn partial_cmp(&self, other: &HTTPVersion) -> Option<Ordering> {
+        let &(major, minor) = self;
+        HTTPVersion(major, minor).partial_cmp(other)
+    }
+}
+
+impl From<(u8, u8)> for HTTPVersion {
+    fn from((major, minor): (u8, u8)) -> HTTPVersion {
+        HTTPVersion(major, minor)
+    }
+}
+
 
 #[cfg(test)]
 mod test {

--- a/src/response.rs
+++ b/src/response.rs
@@ -116,7 +116,7 @@ fn choose_transfer_encoding(request_headers: &[Header], http_version: &HTTPVersi
     use util;
 
     // HTTP 1.0 doesn't support other encoding
-    if *http_version <= HTTPVersion(1, 0) {
+    if *http_version <= (1, 0) {
         return TransferEncoding::Identity;
     }
 


### PR DESCRIPTION
Allows turning a `(u8, u8)` into an `HTTPVersion`, and allows comparisons and equality.