### PR TITLE
Add a Header::from_bytes method

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -126,16 +126,30 @@ impl From<u32> for StatusCode {
 }
 
 /// Represents a HTTP header.
-///
-/// The easiest way to create a `Header` object is to call `parse`.
-///
-/// ```
-/// let header: tiny_http::Header = "Content-Type: text/plain".parse().unwrap();
-/// ```
 #[derive(Debug, Clone)]
 pub struct Header {
     pub field: HeaderField,
     pub value: AsciiString,
+}
+
+impl Header {
+    /// Builds a `Header` from two `Vec<u8>`s or two `&[u8]`s.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/plain"[..]).unwrap();
+    /// ```
+    pub fn from_bytes<B1, B2>(header: B1, value: B2) -> Result<Header, ()>
+                              where B1: Into<Vec<u8>> + AsRef<[u8]>,
+                                    B2: Into<Vec<u8>> + AsRef<[u8]>
+    {
+        let header = try!(HeaderField::from_bytes(header).or(Err(())));
+        let value = try!(AsciiString::from_bytes(value).or(Err(())));
+
+        Ok(Header { field: header, value: value })
+    }
+
 }
 
 impl FromStr for Header {
@@ -182,6 +196,10 @@ impl Display for Header {
 pub struct HeaderField(AsciiString);
 
 impl HeaderField {
+    pub fn from_bytes<B>(bytes: B) -> Result<HeaderField, B> where B: Into<Vec<u8>> + AsRef<[u8]> {
+        AsciiString::from_bytes(bytes).map(|s| HeaderField(s))
+    }
+
     pub fn as_str<'a>(&'a self) -> &'a AsciiStr {
         match self { &HeaderField(ref s) => s }
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -80,10 +80,9 @@ impl FromStr for TransferEncoding {
 }
 
 /// Builds a Date: header with the current date.
-// TODO: this is optimisable
 fn build_date_header() -> Header {
     // FIXME: right date
-    FromStr::from_str("Date: Wed, 15 Nov 1995 06:25:24 GMT").unwrap()
+    Header::from_bytes(&b"Date"[..], &b"Wed, 15 Nov 1995 06:25:24 GMT"[..]).unwrap()
 }
 
 fn write_message_header<W>(mut writer: W, http_version: &HTTPVersion,


### PR DESCRIPTION
Currently it's very annoying to build a `Header`, and the docs recommend parsing `Header: value`, which is not optimal performance-wise.