### PR TITLE
Allow binding to a nic by specifying the socket address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,12 @@ impl ServerBuilder {
         self
     }
 
+    /// The server will bind to the nic:port specified by address
+    pub fn with_address(mut self, address: net::SocketAddrV4) -> ServerBuilder {
+        self.address = address;
+        self
+    }
+
     /// The server will use a random port.
     ///
     /// Call `server.server_addr()` to retreive it once the server is created.


### PR DESCRIPTION
Hello! I needed to bind to a specific nic (rather than all of them), so I added the ability to override the address in the builder.

Cheers,

Phil