### PR TITLE
[breaking change] Rework the server creation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ extern crate tiny_http;
 ### Usage
 
 ```rust
-use tiny_http::{ServerBuilder, Response};
+use tiny_http::{Server, Response};
 
-let server = ServerBuilder::new().with_port(8000).build().unwrap();
+let server = Server::http("0.0.0.0:8000").unwrap();
 
 for request in server.incoming_requests() {
     println!("received request! method: {:?}, url: {:?}, headers: {:?}",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 #[ignore]
 // TODO: obtain time
 fn curl_bench() {
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port;
     let num_requests = 10usize;
 
@@ -30,7 +30,7 @@ fn curl_bench() {
 fn sequential_requests(bencher: &mut test::Bencher) {
     ::std::io::test::raise_fd_limit();
 
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port;
 
     let mut stream = std::io::net::tcp::TcpStream::connect("127.0.0.1", port).unwrap();
@@ -50,7 +50,7 @@ fn sequential_requests(bencher: &mut test::Bencher) {
 fn parallel_requests(bencher: &mut test::Bencher) {
     ::std::io::test::raise_fd_limit();
 
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port;
 
     bencher.bench_n(5, |_| {

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 use std::thread;
 
 fn main() {
-    let server = Arc::new(tiny_http::ServerBuilder::new().with_port(9975).build().unwrap());
+    let server = Arc::new(tiny_http::Server::http("0.0.0.0:9975").unwrap());
     println!("Now listening on port 9975");
 
     let mut handles = Vec::new();
 
-    for _ in (0 .. 4) {
+    for _ in 0 .. 4 {
         let server = server.clone();
 
         handles.push(thread::spawn(move || {

--- a/examples/php-cgi.rs
+++ b/examples/php-cgi.rs
@@ -70,7 +70,7 @@ fn main() {
         args.nth(1).unwrap()
     };
 
-    let server = Arc::new(tiny_http::ServerBuilder::new().with_port(9975).build().unwrap());
+    let server = Arc::new(tiny_http::Server::http("0.0.0.0:9975").unwrap());
     println!("Now listening on port 9975");
 
     let num_cpus = 4;  // TODO: dynamically generate this value

--- a/examples/readme-example.rs
+++ b/examples/readme-example.rs
@@ -1,9 +1,9 @@
 extern crate tiny_http;
 
 fn main() {
-    use tiny_http::{ServerBuilder, Response};
+    use tiny_http::{Server, Response};
 
-    let server = ServerBuilder::new().with_port(8000).build().unwrap();
+    let server = Server::http("0.0.0.0:8000").unwrap();
 
     for request in server.incoming_requests() {
         println!("received request! method: {:?}, url: {:?}, headers: {:?}",

--- a/examples/serve-root.rs
+++ b/examples/serve-root.rs
@@ -25,7 +25,7 @@ fn get_content_type(path: &Path) -> &'static str {
 
 fn main() {
     use ascii::AsciiCast;
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:8000").unwrap();
     let port = server.server_addr().port();
     println!("Now listening on port {}", port);
 

--- a/examples/websockets.rs
+++ b/examples/websockets.rs
@@ -53,7 +53,7 @@ fn convert_key(input: &str) -> String {
 }
 
 fn main() {
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port;
 
     println!("Server started");

--- a/src/request.rs
+++ b/src/request.rs
@@ -281,7 +281,7 @@ impl Request {
     /// # use std::io::Read;
     /// # fn get_content_type(_: &tiny_http::Request) -> &'static str { "" }
     /// # fn main() {
-    /// # let server = tiny_http::ServerBuilder::new().build().unwrap();
+    /// # let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     /// let mut request = server.recv().unwrap();
     ///
     /// if get_content_type(&request) == "application/json" {

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -97,7 +97,7 @@ fn pipelining_test() {
 
 #[test]
 fn server_crash_results_in_response() {
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port();
     let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -4,7 +4,7 @@ use tiny_http;
 
 /// Creates a server and a client connected to the server.
 pub fn new_one_server_one_client() -> (tiny_http::Server, TcpStream) {
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port();
     let client = TcpStream::connect(("127.0.0.1", port)).unwrap();
     (server, client)
@@ -14,7 +14,7 @@ pub fn new_one_server_one_client() -> (tiny_http::Server, TcpStream) {
 /// 
 /// The server will automatically close after 3 seconds.
 pub fn new_client_to_hello_world_server() -> TcpStream {
-    let server = tiny_http::ServerBuilder::new().with_random_port().build().unwrap();
+    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().port();
     let client = TcpStream::connect(("127.0.0.1", port)).unwrap();
 


### PR DESCRIPTION
Fix #101 
Fix #104 

The `ToSocketAddr` trait is specially conceived to be passed to `TcpListener::bind`, so we should use it directly.

Also, the port 0 seems to be a standard for "a random available port", so there's no need for the `with_random_port` function anymore.

I went with a public `ServerConfig` in order to make things explicit. This struct can be extended in the future with things such as `client_timeout`, `ssl` (cc #11) or `max_clients` (cc #26). Users are encouraged to call `http` instead of `new`.

Note that I removed the `client_timeout` parameter because I noticed it was unused anyway.
