### PR TITLE
Request::respond returns a IoResult

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -15,7 +15,7 @@ fn main() {
         handles.push(thread::spawn(move || {
             for rq in server.incoming_requests() {
                 let response = tiny_http::Response::from_string("hello world".to_string());
-                rq.respond(response);
+                let _ = rq.respond(response);
             }
         }));
     }

--- a/examples/serve-root.rs
+++ b/examples/serve-root.rs
@@ -51,11 +51,11 @@ fn main() {
                 }
             );
 
-            rq.respond(response);
+            let _ = rq.respond(response);
 
         } else {
             let rep = tiny_http::Response::new_empty(tiny_http::StatusCode(404));
-            rq.respond(rep);
+            let _ = rq.respond(rep);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ All that remains to do is call `request.respond()`:
 # let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
 # let request = server.recv().unwrap();
 # let response = tiny_http::Response::from_file(File::open(&Path::new("image.png")).unwrap());
-request.respond(response)
+let _ = request.respond(response);
 ```
 */
 #![crate_name = "tiny_http"]

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -126,13 +126,13 @@ fn responses_reordered() {
         let rq2 = server.recv().unwrap();
 
         thread::spawn(move || {
-            rq2.respond(tiny_http::Response::from_string(format!("second request")));
+            rq2.respond(tiny_http::Response::from_string(format!("second request"))).unwrap();
         });
 
         thread::sleep_ms(100);
 
         thread::spawn(move || {
-            rq1.respond(tiny_http::Response::from_string(format!("first request")));
+            rq1.respond(tiny_http::Response::from_string(format!("first request"))).unwrap();
         });
     });
 

--- a/tests/simple-test.rs
+++ b/tests/simple-test.rs
@@ -13,7 +13,7 @@ fn basic_handling() {
     let request = server.recv().unwrap();
     assert!(*request.method() == tiny_http::Method::Get);
     //assert!(request.url() == "/");
-    request.respond(tiny_http::Response::from_string(format!("hello world")));
+    request.respond(tiny_http::Response::from_string(format!("hello world"))).unwrap();
 
     server.try_recv().unwrap();
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -25,7 +25,7 @@ pub fn new_client_to_hello_world_server() -> TcpStream {
             match server.try_recv().unwrap() {
                 Some(rq) => {
                     let response = tiny_http::Response::from_string("hello world".to_string());
-                    rq.respond(response);
+                    rq.respond(response).unwrap();
                 },
                 _ => ()
             };


### PR DESCRIPTION
For the moment the `respond` function ignored errors.
This PR moves this responsibility to the user.

If the user wants to make sure that the response has been sent, it's now possible.
In any real-life scenario, you will probably just write `let _ = request.respond(..);`

This is not a breaking change, but it adds an unused result warning to the users' code.
