### PR TITLE
Correct documentation generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
   - cargo test -v -j 1 --no-default-features --features "$FEATURES"
 
 after_success: |
+  [ $TRAVIS_BRANCH = master ] &&
+  [ $TRAVIS_PULL_REQUEST = false ] &&
   cargo doc && \
   echo '<meta http-equiv=refresh content=0;url=tiny_http/index.html>' > target/doc/index.html && \
   sudo pip install ghp-import && \


### PR DESCRIPTION
Only generate documentation for the master branch and exclude pull requests.

For example this PR will generate docs and write to `gh-pages` before being merged, which is bad.