### PR TITLE
Add try_recv_timeout function to the server

### DIFF
--- a/src/util/messages_queue.rs
+++ b/src/util/messages_queue.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::{Duration, Instant};
 use std::sync::{Arc, Mutex, Condvar};
 
 pub struct MessagesQueue<T> where T: Send {
@@ -38,5 +39,26 @@ impl<T> MessagesQueue<T> where T: Send {
     pub fn try_pop(&self) -> Option<T> {
         let mut queue = self.queue.lock().unwrap();
         queue.pop_front()
+    }
+
+    /// Tries to pop an element without blocking
+    /// more than the specified timeout duration
+    pub fn pop_timeout(&self, timeout: Duration) -> Option<T> {
+        let mut queue = self.queue.lock().unwrap();
+        let mut duration = timeout;
+        loop {
+            if let Some(elem) = queue.pop_front() {
+                return Some(elem);
+            }
+            let now = Instant::now();
+            let (_queue, result) = self.condvar.wait_timeout(queue, timeout).unwrap();
+            queue = _queue;
+            let sleep_time = now.elapsed();
+            duration = if duration > sleep_time { duration - sleep_time } else { Duration::from_millis(0) };
+            if result.timed_out() ||
+               (duration.as_secs() == 0 && duration.subsec_nanos() < 1000000) {
+                return None;
+            }
+        }
     }
 }


### PR DESCRIPTION
Please be warned I'm new to rust :)

This allows giving up on receiving a request after a specified timeout duration.

It's working for me.

I wouldn't strictly need this if I knew how to kill/stop the thread pool from another thread and force the recv() to unblock. In C you can kill the thread and if blocked on a syscall you get an error back from the syscall, you can check EINTR and decide whether to quit or issue the syscall again. I'm not sure how one would implement such a thing in rust, so the next best thing was to simply timeout on recv() and I can check out on my app once in a while for a shutdown flag.