### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/util/refined_tcp_stream.rs
+++ b/src/util/refined_tcp_stream.rs
@@ -25,7 +25,7 @@ pub struct RefinedTcpStream {
     close_write: bool,
 }
 
-enum Stream {
+pub enum Stream {
     Http(TcpStream),
     #[cfg(feature = "ssl")]
     Https(SslStream<TcpStream>),

--- a/src/util/task_pool.rs
+++ b/src/util/task_pool.rs
@@ -15,6 +15,7 @@
 use std::sync::{Arc, Mutex, Condvar};
 use std::sync::atomic::{Ordering, AtomicUsize};
 use std::collections::VecDeque;
+use std::time::Duration;
 use std::thread;
 
 /// Manages a collection of threads.
@@ -122,11 +123,11 @@ impl TaskPool {
                             true
 
                         } else {
-                            let (new_lock, receved) = sharing.condvar
-                                                             .wait_timeout_ms(todo, 5000)
+                            let (new_lock, waitres) = sharing.condvar
+                                                             .wait_timeout(todo, Duration::from_millis(5000))
                                                              .unwrap();
                             todo = new_lock;
-                            receved
+                            !waitres.timed_out()
                         };
 
                         if !received && todo.is_empty() {


### PR DESCRIPTION
I noticed several warnings when compiling (I'm using rustc 1.10.0) so I decided to fix them
 
* Change condition use of wait_timeout_ms to wait_timeout
* Make Stream enum public since it's part of a public interface
* Use close trigger in the server accept thread

The only change that I was unsure of is the close trigger. I assumed the intention of that variable would be to shutdown the accept thread. I think some work may still be needed in that area to properly shutdown everything when the Server is destroyed. I did some tests and it seems the socket is not properly closed (lsof still shows the tcp socket open even though the Server reference was destroyed). For now this gets rid of the warnings, I'll see if I have time to debug the socket leak problem later.