### PR TITLE
Start using the log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ openssl = { version = "0.7", optional = true }
 rustc-serialize = "0.3"
 url = "0.2"
 chrono = "0.2.15"
+log = "0.3"


### PR DESCRIPTION
I did this while debugging the issue for PR #120

Users of the library can then decide what logging framework
to use (if any) and get useful debug information.