### PR TITLE
Fix websockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ rustc-serialize = "0.3"
 url = "0.2"
 chrono = "0.2.15"
 log = "0.3"
+
+[dev-dependencies]
+sha1 = "0.2.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -237,14 +237,16 @@ impl Iterator for ClientConnection {
                     .find(|h| h.field.equiv(&"Connection"))
                     .map(|h| AsRef::<str>::as_ref(h.value.as_ref()));
 
-                match connection_header {
-                    Some(val) if val.eq_ignore_ascii_case("close") =>
+                let lowercase = connection_header.map(|h| h.to_ascii_lowercase());
+
+                match lowercase {
+                    Some(ref val) if val.contains("close") =>
                         self.no_more_requests = true,
 
-                    Some(ref val) if val.eq_ignore_ascii_case("upgrade") =>
+                    Some(ref val) if val.contains("upgrade") =>
                         self.no_more_requests = true,
 
-                    Some(ref val) if !val.eq_ignore_ascii_case("keep-alive") &&
+                    Some(ref val) if !val.contains("keep-alive") &&
                                     *rq.http_version() == HTTPVersion(1, 0) =>
                         self.no_more_requests = true,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ use client::ClientConnection;
 use util::MessagesQueue;
 
 pub use common::{Header, HeaderField, HTTPVersion, Method, StatusCode};
-pub use request::Request;
+pub use request::{Request, ReadWrite};
 pub use response::{ResponseBox, Response};
 
 mod client;


### PR DESCRIPTION
Changes:

- Added the `ReadWrite` trait to make the `Request::upgrade` function compile again. This was likely broken because of a change in Rust. The logic of the function didn't change.
- Made the websockets example compile. It was using some very old code that needed an upgrade.
- I noticed that browsers send `Connection: keep-alive, upgrade` instead of just `Connection: upgrade` so I replaced (pseudo-code) `header == "keep-alive"` with `header.contains("keep-alive")` and same for `upgrade`.
