### PR TITLE
Drop the request reader earlier

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -368,6 +368,9 @@ impl Request {
     fn respond_impl<R>(&mut self, response: Response<R>) -> Result<(), IoError>
         where R: Read
     {
+        // Droping the request reader now so that further requests can start processing immediately.
+        self.data_reader = None;
+
         let mut writer = self.into_writer_impl();
 
         let do_not_send_body = self.method == Method::Head;
@@ -396,6 +399,9 @@ impl fmt::Debug for Request {
 
 impl Drop for Request {
     fn drop(&mut self) {
+        // Droping the request reader now so that further requests can start processing immediately.
+        self.data_reader = None;
+
         if self.response_writer.is_some() {
             let response = Response::empty(500);
             let _ = self.respond_impl(response);        // ignoring any potential error


### PR DESCRIPTION
Before:

- Client sends request A and B to the same socket. Request A has a body.
- Server reads the headers of request A (but not the body) and builds a `Response`.
- Server sends the response back to the client.
- Server then processes request B.

After:

- Client sends request A and B to the same socket. Request A has a body.
- Server reads the headers of request A (but not the body) and builds a `Response`.
- Server processes request B while it sends the response back to the client in another thread.

In other words, without this change you can't start processing the next request before the first response has been entirely transmitted back.
